### PR TITLE
Translate documentation to English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# 星闪悦动文档
+# Sparklink PlayJoy Documentation
 
-## 公司简介
+## Company Profile
 
-星闪悦动科技有限公司是一家专业为客户提供键盘技术咨询、产品定制等服务的国家高新技术企业。公司专注于键盘产品解决方案的研发，研发团队对市场及技术非常熟悉，用专业高效的服务满足客户的键盘制品需求。我们秉承着以客户为中心，力求为客户提供最优质的方案设计、最诚信的商务服务、最专业的技术支持，在键盘行业不断精益求精。
+Sparklink PlayJoy Technology Co., Ltd. is a national high-tech enterprise offering keyboard technology consulting and product customization services. We focus on the research and development of keyboard solutions, and our team is deeply familiar with market and technology trends. With a customer-centric approach, we provide optimal design solutions, trustworthy business services, and professional technical support, continually striving for excellence in the keyboard industry.
 
-## 联系方式
+## Contact
 
-邮件<sparklinkplayjoy@163.com>
+Email <sparklinkplayjoy@163.com>

--- a/index.md
+++ b/index.md
@@ -1,27 +1,23 @@
 ---
-
 layout: home
-
 hero:
-  name: "星闪悦动"
-  tagline: 最好的外设方案制作商
+  name: "Sparklink PlayJoy"
+  tagline: The best peripheral-solution provider
   actions:
     - theme: brand
-      text: 了解我们
+      text: Learn about us
       link: http://www.sparklinkplayjoy.com/
     - theme: alt
-      text: 快速开始
+      text: Quick start
       link: /keyboard
-
 features:
   - icon: ⌨️
-    title: 优点1
-    details: 专业的磁轴方案定制专家
-  - icon: 🖱️ 
-    title: 优点2
-    details: 专注于提供最优质的磁轴方案
+    title: Advantage 1
+    details: Specialists in customized magnetic-switch solutions
+  - icon: 🖱️
+    title: Advantage 2
+    details: Dedicated to delivering top-quality magnetic-switch solutions
   - icon: 💻
-    title: 优点3
-    details: 专业的磁轴方案制作团队
+    title: Advantage 3
+    details: Professional team for magnetic-switch solutions
 ---
-

--- a/keyboard/index.md
+++ b/keyboard/index.md
@@ -1,26 +1,22 @@
-# 键盘SDK文档
+# Keyboard SDK Documentation
 
-由于浏览器安全机制问题在调用sdk时候需要走的是hid协议，所以在最开始需要进行浏览器授权，授权成功后才能调用sdk。
+Because of browser security mechanisms, the SDK communicates over the HID protocol. You must grant browser permission before calling the SDK.
 
-## 开始
+## Getting Started
 
-### 引入
-
+### Install
 ```bash
-pnpm add  @sparklinkplayjoy/sdk-keyboard
-
+pnpm add @sparklinkplayjoy/sdk-keyboard
 ```
 
-## 搭建项目
+## Project Setup
 
-### 项目引用
-
-1. 引入
-
+### Integrate into your project
+1. Import
 ```js
 import Keyboard from '@sparklinkplayjoy/sdk-keyboard'
-const vendorId = 00 // you vid 
-const productId = 00 // you pid 
+const vendorId = 00 // your VID
+const productId = 00 // your PID
 const ServiceKeyboard = new Keyboard({
   configs: [{ vendorId, productId, usagePage: 65440, usage: 1 }],
   usage: 1,
@@ -28,45 +24,42 @@ const ServiceKeyboard = new Keyboard({
 });
 ```
 
-2. 获取授权
-
+2. Request authorization
 ```js
-// 得到当前的设置列表
+// Get the current device list
 const devices = await ServiceKeyboard.getDevices()
 ```
 
-3. 初始化设备
-
+3. Initialize a device
 ```js
-// 从当前设备列表中获取其中一个设备
+// Pick one device from the list
 const { id } = devices[0]
 const result = await ServiceKeyboard.init(id)
 ```
 
-4. 监听hid拔插事件
-
+4. Listen for HID plug/unplug events
 ```js
 services.on("usbChange", (data) => {
-          const { device } = data;
+  const { device } = data;
 
-          if (data.type === 'disconnect' || data.type === 'isUpgrading_disconnect') {
-          }
-          if (data.type === 'connect' || (data.type === 'isUpgrading_connect' && data.reconnect)) {
-            if (device?.collections?.length) {
-              try {
-                const targetCollection = device.collections.find(
-                  (collection) => collection.usage === 1 && collection.usagePage === 0xffb0,
-                );
+  if (data.type === 'disconnect' || data.type === 'isUpgrading_disconnect') {
+  }
+  if (data.type === 'connect' || (data.type === 'isUpgrading_connect' && data.reconnect)) {
+    if (device?.collections?.length) {
+      try {
+        const targetCollection = device.collections.find(
+          (collection) => collection.usage === 1 && collection.usagePage === 0xffb0,
+        );
 
-                if (targetCollection) {
-                 
-                }
-              } catch (error) {
-                
-              }
-            } 
-          }
-        });
+        if (targetCollection) {
 
-services.off('usbChange',listener) // 移除监听
+        }
+      } catch (error) {
+
+      }
+    }
+  }
+});
+
+services.off('usbChange', listener) // remove listener
 ```

--- a/keyboard/model.md
+++ b/keyboard/model.md
@@ -1,7 +1,3 @@
-# 模型
-
-## 设备
-
 ```ts
 interface HIDCollectionInfo {
   usagePage: number;
@@ -29,8 +25,8 @@ interface HIDDevice extends EventTarget {
 }
 
 type Device = {
-   data: HIDDevice, // 设备信息
-   id: string, // 设备id
+   data: HIDDevice, // device information
+   id: string, // device ID
    usage: number, // usage
    usagePage: number, // usagePage
    vendorId: number, // vendorId
@@ -63,13 +59,13 @@ enum RateOfReturn {
 }
 
 interface Calibration {
-  calibrations: number[][], // 包含所有按键的最大行程值
-  travels: number[][], // 包含所有按键按下的行程值
+  calibrations: number[][], // maximum travel values for all keys
+  travels: number[][], // travel values when all keys are pressed
 }
 
 ```
 
-## 布局模型
+## Layout model
 
 ```ts
 [
@@ -83,45 +79,45 @@ interface Calibration {
 ]
 ```
 
-## 单键的布局模型
+## Single-key layout model
 
 ```ts
 type IDefKeyInfo = {
-  keyValue: number; // 键值
+  keyValue: number; // key value
   location: {
-    row: number; // 行
-    col: number; // 列
+    row: number; // row
+    col: number; // column
   };
 }
 ```
 
-## 灯光
+## Lighting
 
 ```ts
 
-// 灯光模型
+// Lighting model
 type LightMode = {
-  open: boolean; // 是否开启灯光
-  direction: boolean; // 方向 true 正向 false 反向
-  superResponse: boolean; // 超强响应
-  speed: number; // 灯光速度
-  colors: string[]; // 颜色组
-  mode: number; // 0 关闭, 1-20表示效果，21 自定义
-  luminance: number; // 亮度
-  sleepDelay: number; // 灯光休眠时间
-  staticColor: number; // 静态灯光颜色模式
+  open: boolean; // whether lighting is on
+  direction: boolean; // direction true: forward, false: reverse
+  superResponse: boolean; // super response
+  speed: number; // lighting speed
+  colors: string[]; // color set
+  mode: number; // 0 off, 1-20 effects, 21 custom
+  luminance: number; // brightness
+  sleepDelay: number; // lighting sleep time
+  staticColor: number; // static lighting color mode
   type: LightModeType;
-  // LightModeType = 'static' | 'custom' | 'dynamic';   
-  // type的类型：custom 自定义模式，static 静态模式，dynamic 动态模式。
-  // 当设置Logo灯的时候type只有static静态模式和dynamic动态模式两种模式。
+  // LightModeType = 'static' | 'custom' | 'dynamic';
+  // type: custom = custom mode, static = static mode, dynamic = dynamic mode.
+  // When setting the logo light, only static and dynamic modes are available.
 };
 
-// 灯光Type
+// Lighting type
 type LightModeType = 'custom' | 'static' | 'dynamic';
 
 ```
 
-## 高级键
+## Advanced keys
 
 ```ts
 type TrpsLayoutType = 'Layout_TRPS1' | 'Layout_TRPS2' | 'Layout_TRPS3' | 'Layout_TRPS4';
@@ -146,13 +142,13 @@ interface ISOCDModeV2 {
   mode: number;
 }
 interface ISOCDModeV3 {
-  pos1: number; // 原键值
-  pos2: number; // 原键值
-  key1: number; // 发送键值
-  key2: number; // 发送键值
-  type: number; // 发送键值类型 0=按pos发送键值，1=按Key发送键值，默认:0
-  mode: number; // 发送键值模式 mode表示键值的发送模式，共有四种模式：0=后覆盖，1=a优先，2=b优先，3=中性（两个按键都按下都不生效）,默认:0
-  delay: number; // 发送键值延迟
+  pos1: number; // original key value
+  pos2: number; // original key value
+  key1: number; // key value to send
+  key2: number; // key value to send
+  type: number; // key value type 0=send by position, 1=send by key value, default:0
+  mode: number; // key sending mode: 0=override later, 1=A priority, 2=B priority, 3=neutral (no key when both pressed), default:0
+  delay: number; // key sending delay
 }
 interface IEndMode {
   key: number;
@@ -161,7 +157,7 @@ interface IEndMode {
 }
 ```
 
-## 宏
+## Macro
 
 ```ts
 
@@ -175,6 +171,5 @@ interface IMacroMode {
 }
 
 type MacroType = { keyCode: number; timeDifference: number; status: number };
-
 
 ```

--- a/keyboard/type.md
+++ b/keyboard/type.md
@@ -1,47 +1,47 @@
-# 类型查询
+# Type Reference
 
 ## getApi
 
-```ts type 目前支持类型
-  ORDER_TYPE_PROTOCOL_VERSION = 0x01, // 获取协议版本
-  ORDER_TYPE_SAVING_PARAMETER = 0x02, // 手动保存参数
-  ORDER_TYPE_RELOAD_PARAMETERS = 0x03, // 重新加载参数
-  ORDER_TYPE_CLEAR_CALIBRATION_DATA = 0x04, // 清除校准数据
-  ORDER_TYPE_OPEN_DKS = 0x05, // 开启 DKS
-  ORDER_TYPE_CLOSE_DKS = 0x06, // 关闭 DKS
-  ORDER_TYPE_REVERSE = 0x07, // 反向
-  ORDER_TYPE_TURN_ON_REMAPPING = 0x08, // 开启重映射
-  ORDER_TYPE_TURN_OFF_REMAPPING = 0x09, // 关闭重映射
-  ORDER_TYPE_ENABLE_RELATIVE_TRIGGER = 0x0a, // 开启相对触发
-  ORDER_TYPE_TURN_OFF_RELATIVE_TRIGGER = 0x0b, // 关闭相对触发
-  ORDER_TYPE_START_CALIBRATION = 0x0c, // 开启校准,保留项，s_arg为霍尔电压最大最小变化范围（单位mV）
-  ORDER_TYPE_CLOSE_CALIBRATION = 0x0d, // 关闭校准,保留项，s_arg =0表示已退出
-  ORDER_TYPE_START_DEMONSTRATION = 0x0e, // 演示功能打开
-  ORDER_TYPE_CLOSE_DEMONSTRATION = 0x0f, // 演示功能关闭
-  ORDER_TYPE_ERASE_MACROSTORAGE = 0x10, // 宏参数保存前需调用该指令擦除相应的存储区
-  ORDER_TYPE_RESTORE_FACTORY_SETTINGS = 0x11, // 恢复出厂设置,等待响应超时应 > 200ms
-  // query 指令返回 s_arg参数为 1表示查询为真,即所查询的内容被确认为真,其它值为否
-  ORDER_TYPE_LOCK_WIN_KEY = 0x20, // query, 查询锁WIN键
-  ORDER_TYPE_QUERY_WIN_MODEL = 0x21, // query, 查询是否为 Win 模式
-  ORDER_TYPE_QUERY_MAC_MODEL = 0x22, // query, 查询是否为 Mac 模式
-  ORDER_TYPE_QUERY_STANDARD_MODEL = 0x23, // query, 查询是否为 标准 模式
-  ORDER_TYPE_QUERY_ADJUSTABLE_SPEEDMODEL = 0x24, // query, 查询是否为 可调行程 模式
-  ORDER_TYPE_PRECISION_STROKE = 0x25, // 8bit精度+16bit最小行程度+16bit最大行程。以um为单位，如10精度(10um)为0.01mm,50精度(50um)为0.05mm。行程范围0~4000um。
-  ORDER_TYPE_KEYBOARD_NAME = 0x26, // 读取键盘名字
-  ORDER_TYPE_SET_WIN_MODEL = 0x30, // switch, 切换到 Win 模式，s_arg =1表示成功
-  ORDER_TYPE_SET_MAC_MODEL = 0x31, // switch, 切换到 Mac 模式，s_arg =1表示成功
-  ORDER_TYPE_SET_STANDARD_MODEL = 0x32, // switch, 切换到 标准 模式
-  ORDER_TYPE_SET_ADJUSTABLE_SPEEDMODEL = 0x33, // switch, 切换到 可调行程 模式
-  ORDER_TYPE_TOP_DEAD_SWITCH = 0x34, // 顶部死区
-  ORDER_TYPE_RGB1 = 0x40, // 写入 RGB 灰度 1, h_arg = 0xFF 为无效，s_arg表示返回灰度值
-  ORDER_TYPE_RGB2 = 0x41, // 写入 RGB 灰度 2
-  ORDER_TYPE_RGB3 = 0x42, // 写入 RGB 灰度 3
-  ORDER_TYPE_RGB4 = 0x43, // 写入 RGB 灰度 4
-  ORDER_TYPE_ROES = 0x50, // 设置回报率, h_arg / s_arg = 0[8KHz], 1[4KHz], 2[2KHz], 3[1KHz], 4[500Hz], 5[250Hz]，6[125Hz], 无效，只可用于获取当前的回报率
-  ORDER_TYPE_WEB = 0x60, // 一键打开网址设置，h_arg[n] = 网址字符ascii码，最长50字节
-  ORDER_TYPE_SOCD = 0x61, // 快速开启/关闭SOCD功能，h_arg=0x00关闭SOCD，h_arg=0x01开启SOCD
-  ORDER_TYPE_CONFIG = 0x70, // 切换配置功能，h_arg / s_arg = 0[配置1],1[配置2],2[配置3],3[配置4]，其他参数：查询配置
-  ORDER_TYPE_AXOSOME = 0x75, // 查询键盘支持的轴体ID
-  ORDER_TYPE_CURRENT_AXOSOME = 0x76, // 当前键盘的轴体，s_arg = [uint16,uint]
-
+```ts
+// Supported types
+ORDER_TYPE_PROTOCOL_VERSION = 0x01, // Get protocol version
+ORDER_TYPE_SAVING_PARAMETER = 0x02, // Save parameters manually
+ORDER_TYPE_RELOAD_PARAMETERS = 0x03, // Reload parameters
+ORDER_TYPE_CLEAR_CALIBRATION_DATA = 0x04, // Clear calibration data
+ORDER_TYPE_OPEN_DKS = 0x05, // Enable DKS
+ORDER_TYPE_CLOSE_DKS = 0x06, // Disable DKS
+ORDER_TYPE_REVERSE = 0x07, // Reverse
+ORDER_TYPE_TURN_ON_REMAPPING = 0x08, // Enable remapping
+ORDER_TYPE_TURN_OFF_REMAPPING = 0x09, // Disable remapping
+ORDER_TYPE_ENABLE_RELATIVE_TRIGGER = 0x0a, // Enable relative trigger
+ORDER_TYPE_TURN_OFF_RELATIVE_TRIGGER = 0x0b, // Disable relative trigger
+ORDER_TYPE_START_CALIBRATION = 0x0c, // Start calibration; reserved. s_arg is the max/min Hall voltage change (mV)
+ORDER_TYPE_CLOSE_CALIBRATION = 0x0d, // Stop calibration; reserved. s_arg=0 means exit
+ORDER_TYPE_START_DEMONSTRATION = 0x0e, // Enable demo mode
+ORDER_TYPE_CLOSE_DEMONSTRATION = 0x0f, // Disable demo mode
+ORDER_TYPE_ERASE_MACROSTORAGE = 0x10, // Erase macro storage area before saving macro parameters
+ORDER_TYPE_RESTORE_FACTORY_SETTINGS = 0x11, // Restore factory settings; wait >200ms for response
+// query commands: s_arg = 1 means true, other values mean false
+ORDER_TYPE_LOCK_WIN_KEY = 0x20, // query lock WIN key
+ORDER_TYPE_QUERY_WIN_MODEL = 0x21, // query whether in Win mode
+ORDER_TYPE_QUERY_MAC_MODEL = 0x22, // query whether in Mac mode
+ORDER_TYPE_QUERY_STANDARD_MODEL = 0x23, // query whether in Standard mode
+ORDER_TYPE_QUERY_ADJUSTABLE_SPEEDMODEL = 0x24, // query whether in Adjustable Travel mode
+ORDER_TYPE_PRECISION_STROKE = 0x25, // 8-bit precision + 16-bit min travel + 16-bit max travel in um; range 0~4000um
+ORDER_TYPE_KEYBOARD_NAME = 0x26, // read keyboard name
+ORDER_TYPE_SET_WIN_MODEL = 0x30, // switch to Win mode; s_arg=1 indicates success
+ORDER_TYPE_SET_MAC_MODEL = 0x31, // switch to Mac mode; s_arg=1 indicates success
+ORDER_TYPE_SET_STANDARD_MODEL = 0x32, // switch to Standard mode
+ORDER_TYPE_SET_ADJUSTABLE_SPEEDMODEL = 0x33, // switch to Adjustable Travel mode
+ORDER_TYPE_TOP_DEAD_SWITCH = 0x34, // Top dead zone
+ORDER_TYPE_RGB1 = 0x40, // Write RGB grayscale 1; h_arg = 0xFF invalid, s_arg returns grayscale
+ORDER_TYPE_RGB2 = 0x41, // Write RGB grayscale 2
+ORDER_TYPE_RGB3 = 0x42, // Write RGB grayscale 3
+ORDER_TYPE_RGB4 = 0x43, // Write RGB grayscale 4
+ORDER_TYPE_ROES = 0x50, // Set report rate: h_arg / s_arg = 0[8KHz], 1[4KHz], 2[2KHz], 3[1KHz], 4[500Hz], 5[250Hz], 6[125Hz]; invalid otherwise; read only
+ORDER_TYPE_WEB = 0x60, // One-click website open; h_arg[n] = URL char ASCII, max 50 bytes
+ORDER_TYPE_SOCD = 0x61, // Quickly enable/disable SOCD; h_arg=0x00 disable, h_arg=0x01 enable
+ORDER_TYPE_CONFIG = 0x70, // Switch profile; h_arg / s_arg = 0[Profile1],1[Profile2],2[Profile3],3[Profile4]; other params query profile
+ORDER_TYPE_AXOSOME = 0x75, // Query supported switch IDs
+ORDER_TYPE_CURRENT_AXOSOME = 0x76, // Current switch ID, s_arg = [uint16,uint]
 ```

--- a/mouse/index.md
+++ b/mouse/index.md
@@ -1,3 +1,3 @@
-# 鼠标SDK
+# Mouse SDK
 
-文档正在构建中。。。 敬请期待!!!
+Documentation is currently under construction... stay tuned!


### PR DESCRIPTION
## Summary
- Translate project README and site landing page to English
- Convert Keyboard SDK introduction, model, type references, and mouse stub docs to English

## Testing
- `pnpm --silent docs:build`

------
https://chatgpt.com/codex/tasks/task_e_68c5e42a72308325bbce5949eb99646d